### PR TITLE
Show status bar

### DIFF
--- a/style/variables.css
+++ b/style/variables.css
@@ -340,6 +340,10 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-toolbar-header-margin: 4px 4px 0px 4px;
   --jp-toolbar-active-background: var(--jp-layout-color0);
 
+  /* Statusbar specific styles */
+
+  --jp-statusbar-height: 24px;
+
   /* Input field styles */
 
   --jp-input-box-shadow: inset 0 0 2px var(--md-blue-300);


### PR DESCRIPTION
The status bar is hidden when turning on this theme.

We add the style variable `--jp-statusbar-height` used in the built-in [dark theme extension](https://github.com/jupyterlab/jupyterlab/blob/0040f2649c77af0251b8c8f73aea91c26c3960c5/packages/theme-dark-extension/style/variables.css#L317) to bring the status bar back.